### PR TITLE
Readding deleted git badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(master)%20pipeline/lastBuild/)
+[![Jenkins Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(master)%20pipeline/lastBuild/jacoco/)
+[![Unit Tests](https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(master)%20pipeline/lastBuild/testReport/)
+[![Security Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28master%29%2520pipeline%2F&label=security%20tests)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(master)%20pipeline/lastBuild/zap/)
+[![Integration Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28master%29%2520pipeline%2F&label=integration%20tests)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(master)%20pipeline/lastBuild/Integration_20Test_20Report/)
 
 ![IUDX](./docs/iudx.png)
 


### PR DESCRIPTION
Readded git badges for Jenkins CI test reports which were removed in this [commit](https://github.com/datakaveri/iudx-gis-interface/commit/2e5ce2455ddfbca2346fe01a6d67c008db33b446).