### PR TITLE
Updated to refer configs archived for release 3.5.0 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
           script{
             startZap ([host: 'localhost', port: 8090, zapHome: '/var/lib/jenkins/tools/com.cloudbees.jenkins.plugins.customtools.CustomTool/OWASP_ZAP/ZAP_2.11.0'])
             sh 'curl http://127.0.0.1:8090/JSON/pscan/action/disableScanners/?ids=10096'
-            sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/gis/Newman/IUDX_GIS_Server_APIs_V3.5.postman_collection.json -e /home/ubuntu/configs/gis-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/gis/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
+            sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/gis/Newman/IUDX_GIS_Server_APIs_V3.5.postman_collection.json -e /home/ubuntu/configs/3.5.0/gis-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/gis/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
             runZapAttack()
           }
         }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,8 +13,8 @@ services:
       - LOG_LEVEL=INFO
       - GIS_JAVA_OPTS=-Xmx1024m
     volumes:
-      - /home/ubuntu/configs/gis-config-test.json:/usr/share/app/configs/config-test.json
-      - /home/ubuntu/configs/keystore-gis.jks:/usr/share/app/configs/keystore.jks
+      - /home/ubuntu/configs/3.5.0/gis-config-test.json:/usr/share/app/configs/config-test.json
+      - /home/ubuntu/configs/3.5.0/keystore-gis.jks:/usr/share/app/configs/keystore.jks
       - ./docker/runTests.sh:/usr/share/app/docker/runTests.sh
       - ./src/:/usr/share/app/src
       - ${WORKSPACE}:/tmp/test
@@ -34,8 +34,8 @@ services:
       - LOG_LEVEL=INFO
       - GIS_JAVA_OPTS=-Xmx1024m
     volumes:
-      - /home/ubuntu/configs/gis-config-test.json:/usr/share/app/configs/config-dev.json
-      - /home/ubuntu/configs/keystore-gis.jks:/usr/share/app/configs/keystore.jks
+      - /home/ubuntu/configs/3.5.0/gis-config-test.json:/usr/share/app/configs/config-dev.json
+      - /home/ubuntu/configs/3.5.0/keystore-gis.jks:/usr/share/app/configs/keystore.jks
       - ./src/:/usr/share/app/src
     ports:
       - "8443:8443"


### PR DESCRIPTION
Until now the same config files were being used in all the pipelines (master/PR/3.5.0). But since testing the v4.0 components (master and PR CI) might require changes in the config files, it could end up affecting v3.5.0 CI pipelines.
To avoid this, archiving the current configs for the 3.5.0 pipelines separately and updated references in the CI tests to refer to those.