### PR TITLE
postgres library update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,9 +173,14 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+            <groupId>com.ongres.scram</groupId>
+            <artifactId>client</artifactId>
+            <version>2.1</version>
+        </dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.3.5</version>
+			<version>42.4.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
- Updated postgressql version 42.3.3 -> 42.4.0
- included SCRAM256 lib for postgres.