### PR TITLE
Removal of unused config options in gis

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -194,11 +194,9 @@ In order to connect to the DX catalogue server, required information such as cat
     "id": "iudx.gis.server.authenticator.AuthenticationVerticle",
     "verticleInstances": <number-of-verticle-instances,
     "audience": <gis-server-host>,
-    "host": <host>,
     "authServerHost": <auth-server-host>,
     "catServerHost": <catalogue-server-host>,
     "catServerPort": <catalogue-server-port>,
-    "serverMode": <server-mode>,
     "jwtIgnoreExpiry": <true | false>
 }
 ```
@@ -225,11 +223,9 @@ In order to connect to the DX authentication server, required information such a
    "id": "iudx.gis.server.authenticator.AuthenticationVerticle",
    "verticleInstances": <number-of-verticle-instances,
    "audience": <gis-server-host>,
-   "host": <host>,
    "authServerHost": <auth-server-host>,
    "catServerHost": <catalogue-server-host>,
    "catServerPort": <catalogue-server-port>,
-   "serverMode": <server-mode>,
    "jwtIgnoreExpiry": <true | false>
 }
 ```

--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -20,10 +20,8 @@
       "verticleInstances": 1,
       "audience": "",
       "authServerHost": "",
-      "host": "",
       "catServerHost": "",
       "catServerPort": 0,
-      "serverMode": "",
       "jwtIgnoreExpiry": true
     },
     {

--- a/configs/config-example.json
+++ b/configs/config-example.json
@@ -21,10 +21,8 @@
       "verticleInstances": 1,
       "audience": "",
       "authServerHost": "",
-      "host": "",
       "catServerHost": "",
       "catServerPort": 0,
-      "serverMode": "",
       "jwtIgnoreExpiry": true
     },
     {

--- a/configs/config-test.json
+++ b/configs/config-test.json
@@ -20,10 +20,8 @@
       "verticleInstances": 1,
       "audience": "",
       "authServerHost": "",
-      "host": "",
       "catServerHost": "",
       "catServerPort": 0,
-      "serverMode": "",
       "jwtIgnoreExpiry": true
     },
     {

--- a/src/main/java/iudx/gis/server/configuration/Configuration.java
+++ b/src/main/java/iudx/gis/server/configuration/Configuration.java
@@ -36,7 +36,6 @@ public class Configuration {
       Buffer buff = fileSystem.readFileBlocking(CONFIG_PATH);
       JsonArray conf = buff.toJsonObject().getJsonArray("modules");
       moduleConf = conf.getJsonObject(moduleIndex);
-      moduleConf.put("host", buff.toJsonObject().getString("host"));
 
     } else {
       LOGGER.fatal("Couldn't read configuration file; Path: " + CONFIG_PATH);


### PR DESCRIPTION
- removal of  'serverMode' as
grep -rnw src/ -e 'serverMode' yields nothing
- removal of 'host' as its conveyed through audience field
and is also not used.