### PR TITLE
Jenkins v4.0.0 pipeline updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
 
     stage('Integration Tests & ZAP pen test'){
       steps{
-        node('master') {
+        node('built-in') {
           script{
             startZap ([host: 'localhost', port: 8090, zapHome: '/var/lib/jenkins/tools/com.cloudbees.jenkins.plugins.customtools.CustomTool/OWASP_ZAP/ZAP_2.11.0'])
             sh 'curl http://127.0.0.1:8090/JSON/pscan/action/disableScanners/?ids=10096'
@@ -74,10 +74,10 @@ pipeline {
       }
       post{
         always{
-          node('master') {
+          node('built-in') {
             script{
               publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: '/var/lib/jenkins/iudx/gis/Newman/report/', reportFiles: 'report.html', reportName: 'HTML Report', reportTitles: '', reportName: 'Integration Test Report'])
-              archiveZap failHighAlerts: 1, failMediumAlerts: 1, failLowAlerts: 2
+              archiveZap failHighAlerts: 1, failMediumAlerts: 1, failLowAlerts: 1
             }  
           }
           script{
@@ -87,66 +87,20 @@ pipeline {
       }
     }
 
-    stage('Continuous Deployment') {
-      when {
-        allOf {
-          anyOf {
-            changeset "docker/**"
-            changeset "docs/**"
-            changeset "pom.xml"
-            changeset "src/main/**"
-            triggeredBy cause: 'UserIdCause'
-          }
-          expression {
-            return env.GIT_BRANCH == 'origin/master';
-          }
+   stage('Push Image') {
+      when{
+        expression {
+
+          return env.GIT_BRANCH == 'origin/4.0.0';
         }
       }
-      stages {
-        stage('Push Images') {
-          steps {
-            script {
-              docker.withRegistry( registryUri, registryCredential ) {
-                devImage.push("4.0-alpha-${env.GIT_HASH}")
-                deplImage.push("4.0-alpha-${env.GIT_HASH}")
-              }
-            }
+      steps{
+        script {
+          docker.withRegistry( registryUri, registryCredential ) {
+            devImage.push("4.0.0-${env.GIT_HASH}")
+            deplImage.push("4.0.0-${env.GIT_HASH}")
           }
         }
-        stage('Docker Swarm deployment') {
-          steps {
-            script {
-              sh "ssh azureuser@docker-swarm 'docker service update gis_gis --image ghcr.io/datakaveri/gis-depl:4.0-alpha-${env.GIT_HASH}'"
-              sh 'sleep 10'
-            }
-          }
-          post{
-            failure{
-              error "Failed to deploy image in Docker Swarm"
-            }
-          }
-        }
-        // stage('Integration test on swarm deployment') {
-        //   steps {
-        //     node('master') {
-        //       script{
-        //         sh 'newman run /var/lib/jenkins/iudx/gis/Newman/IUDX_GIS_Server_APIs_V4.0.postman_collection.json -e /home/ubuntu/configs/cd/gis-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/gis/Newman/report/cd-report.html --reporter-htmlextra-skipSensitiveData'
-        //       }
-        //     }
-        //   }
-        //   post{
-        //     always{
-        //       node('master') {
-        //         script{
-        //           publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: '/var/lib/jenkins/iudx/gis/Newman/report/', reportFiles: 'cd-report.html', reportTitles: '', reportName: 'Docker-Swarm Integration Test Report'])
-        //         }
-        //       }
-        //     }
-        //     failure{
-        //       error "Test failure. Stopping pipeline execution!"
-        //     }
-        //   }
-        // }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
           script{
             startZap ([host: 'localhost', port: 8090, zapHome: '/var/lib/jenkins/tools/com.cloudbees.jenkins.plugins.customtools.CustomTool/OWASP_ZAP/ZAP_2.11.0'])
             sh 'curl http://127.0.0.1:8090/JSON/pscan/action/disableScanners/?ids=10096'
-            sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/gis/Newman/IUDX_GIS_Server_APIs_V4.0.postman_collection.json -e /home/ubuntu/configs/gis-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/gis/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
+            sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/gis/Newman/IUDX_GIS_Server_APIs_V4.0.postman_collection.json -e /home/ubuntu/configs/4.0.0/gis-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/gis/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
             runZapAttack()
           }
         }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(master)%20pipeline/lastBuild/)
-[![Jenkins Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(master)%20pipeline/lastBuild/jacoco/)
-[![Unit Tests](https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(master)%20pipeline/lastBuild/testReport/)
-[![Security Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28master%29%2520pipeline%2F&label=security%20tests)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(master)%20pipeline/lastBuild/zap/)
-[![Integration Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28master%29%2520pipeline%2F&label=integration%20tests)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(master)%20pipeline/lastBuild/Integration_20Test_20Report/)
+[![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28v4.0.0%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(v4.0.0)%20pipeline/lastBuild/)
+[![Jenkins Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28v4.0.0%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(v4.0.0)%20pipeline/lastBuild/jacoco/)
+[![Unit Tests](https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28v4.0.0%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(v4.0.0)%20pipeline/lastBuild/testReport/)
+[![Security Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28v4.0.0%29%2520pipeline%2F&label=security%20tests)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(v4.0.0)%20pipeline/lastBuild/zap/)
+[![Integration Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520gis-interface%2520%28v4.0.0%29%2520pipeline%2F&label=integration%20tests)](https://jenkins.iudx.io/job/iudx%20gis-interface%20(v4.0.0)%20pipeline/lastBuild/Integration_20Test_20Report/)
 
 ![IUDX](./docs/iudx.png)
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -46,3 +46,12 @@ services:
              max-file: "5"
              max-size: "100m"
     command: bash -c "exec java $$GIS_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"
+    depends_on:
+      - "zookeeper"  
+  
+  zookeeper:
+    image: zookeeper:latest
+    expose: 
+      - "2181"
+    networks:
+      - gis-net

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,8 +13,8 @@ services:
       - LOG_LEVEL=INFO
       - GIS_JAVA_OPTS=-Xmx1024m
     volumes:
-      - /home/ubuntu/configs/gis-config-test.json:/usr/share/app/configs/config-test.json
-      - /home/ubuntu/configs/keystore-gis.jks:/usr/share/app/configs/keystore.jks
+      - /home/ubuntu/configs/4.0.0/gis-config-test.json:/usr/share/app/configs/config-test.json
+      - /home/ubuntu/configs/4.0.0/keystore-gis.jks:/usr/share/app/configs/keystore.jks
       - ./docker/runTests.sh:/usr/share/app/docker/runTests.sh
       - ./src/:/usr/share/app/src
       - ${WORKSPACE}:/tmp/test
@@ -34,8 +34,8 @@ services:
       - LOG_LEVEL=INFO
       - GIS_JAVA_OPTS=-Xmx1024m
     volumes:
-      - /home/ubuntu/configs/gis-config-test.json:/usr/share/app/configs/config.json
-      - /home/ubuntu/configs/keystore-gis.jks:/usr/share/app/configs/keystore.jks
+      - /home/ubuntu/configs/4.0.0/gis-config-test.json:/usr/share/app/configs/config.json
+      - /home/ubuntu/configs/4.0.0/keystore-gis.jks:/usr/share/app/configs/keystore.jks
     ports:
       - "8443:8443"
     networks: 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -28,15 +28,14 @@ services:
     command: bash -c "docker/runTests.sh"
 
   integTest:
-    image: ghcr.io/datakaveri/gis-test:latest
+    image: ghcr.io/datakaveri/gis-depl:latest
     environment:
       - RS_URL=https://rs.iudx.org.in
       - LOG_LEVEL=INFO
       - GIS_JAVA_OPTS=-Xmx1024m
     volumes:
-      - /home/ubuntu/configs/gis-config-test.json:/usr/share/app/configs/config-dev.json
+      - /home/ubuntu/configs/gis-config-test.json:/usr/share/app/configs/config.json
       - /home/ubuntu/configs/keystore-gis.jks:/usr/share/app/configs/keystore.jks
-      - ./src/:/usr/share/app/src
     ports:
       - "8443:8443"
     networks: 
@@ -46,4 +45,4 @@ services:
          options:
              max-file: "5"
              max-size: "100m"
-    command: bash -c "mvn clean compile exec:java@gis-server"
+    command: bash -c "exec java $$GIS_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c configs/config.json"


### PR DESCRIPTION
- fixed jenkins node label
- updated image tag to `4.0.0-${env.GIT_HASH}`
- archived 4.0.0 configs and updated references
- updated to use depl image for integration test stage
- Updated git badges to point to 4.0.0 pipelines