### PR TITLE
Make server items configurable

### DIFF
--- a/configs/config-dev.json
+++ b/configs/config-dev.json
@@ -6,7 +6,9 @@
   "clusterId": "",
   "commonConfig" : {
     "dxApiBasePath": "/ngsi-ld/v1",
-    "adminBasePath": "/admin/gis"
+    "adminBasePath": "/admin/gis",
+    "dxCatalogueBasePath": "/iudx/cat/v1",
+    "dxAuthBasePath": "/auth/v1"
   },
   "modules": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -31,6 +31,8 @@ info:
         - Base path is the path on which API is served, relative to the host
         - It is the initial part of the API
         - The base path value could be configured according to the deployment
+        - The base path for [DX AAA Server](https://github.com/datakaveri/iudx-aaa-server) is set to `/auth/v1`
+        - The base path for [DX Catalogue Server](https://github.com/datakaveri/iudx-catalogue-server) is set to `/iudx/cat/v1`
         - Currently, `/entities` (Latest search) APIs have `/ngsi-ld/v1` base path and `/serverInfo` (Admin) APIs have `/admin/gis` as base path
           <br>
     - **Request Samples**:

--- a/src/main/java/iudx/gis/server/apiserver/ApiServerVerticle.java
+++ b/src/main/java/iudx/gis/server/apiserver/ApiServerVerticle.java
@@ -73,6 +73,8 @@ public class ApiServerVerticle extends AbstractVerticle {
   private AuthenticationService authenticator;
   public String dxApiBasePath;
   public String adminBasePath;
+  private String dxCatalogueBasePath;
+  private String dxAuthBasePath;
 
   @Override
   public void start() throws Exception {
@@ -94,6 +96,8 @@ public class ApiServerVerticle extends AbstractVerticle {
 
     dxApiBasePath = config().getString("dxApiBasePath");
     adminBasePath = config().getString("adminBasePath");
+    dxCatalogueBasePath = config().getString("dxCatalogueBasePath");
+    dxAuthBasePath = config().getString("dxAuthBasePath");
     Api api = Api.getInstance(dxApiBasePath,adminBasePath);
 
     router = Router.router(vertx);

--- a/src/main/java/iudx/gis/server/apiserver/service/CatalogueService.java
+++ b/src/main/java/iudx/gis/server/apiserver/service/CatalogueService.java
@@ -19,6 +19,9 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static iudx.gis.server.authenticator.Constants.CAT_ITEM_PATH;
+import static iudx.gis.server.authenticator.Constants.CAT_SEARCH_PATH;
+
 public class CatalogueService {
   private static final Logger LOGGER = LogManager.getLogger(CatalogueService.class);
 
@@ -26,9 +29,10 @@ public class CatalogueService {
   private long cacheGroupTimerId;
   private long cacheResTimerId;
   private static String catHost;
-  private static int catPort;;
+  private static int catPort;
   private static String catSearchPath;
   private static String catItemPath;
+  private String catBasePath;
   private Vertx vertx;
 
   private final Cache<String, String> idCache = CacheBuilder.newBuilder().maximumSize(1000)
@@ -41,8 +45,9 @@ public class CatalogueService {
     this.vertx = vertx;
     catHost = config.getString("catServerHost");
     catPort = config.getInteger("catServerPort");
-    catSearchPath = Constants.CAT_RSG_PATH;
-    catItemPath = Constants.CAT_ITEM_PATH;
+    catBasePath = config.getString("dxCatalogueBasePath");
+    catItemPath = catBasePath + CAT_ITEM_PATH;
+    catSearchPath = catBasePath + CAT_SEARCH_PATH;
 
     WebClientOptions options =
         new WebClientOptions().setTrustAll(true).setVerifyHost(false).setSsl(true);

--- a/src/main/java/iudx/gis/server/authenticator/AuthenticationVerticle.java
+++ b/src/main/java/iudx/gis/server/authenticator/AuthenticationVerticle.java
@@ -1,5 +1,6 @@
 package iudx.gis.server.authenticator;
 
+import static iudx.gis.server.authenticator.Constants.AUTH_CERTIFICATE_PATH;
 import static iudx.gis.server.common.Constants.AUTHENTICATION_SERVICE_ADDRESS;
 import static iudx.gis.server.common.Constants.CACHE_SERVICE_ADDRESS;
 
@@ -118,8 +119,9 @@ public class AuthenticationVerticle extends AbstractVerticle {
   public Future<String> getJwtPublicKey(Vertx vertx, JsonObject config) {
     Promise<String> promise = Promise.promise();
     webClient = createWebClient(vertx, config);
+    String authCert = config.getString("dxAuthBasePath") + AUTH_CERTIFICATE_PATH;
     webClient
-        .get(443, config.getString("authServerHost"), "/auth/v1/cert")
+        .get(443, config.getString("authServerHost"), authCert)
         .send(
             handler -> {
               if (handler.succeeded()) {

--- a/src/main/java/iudx/gis/server/authenticator/Constants.java
+++ b/src/main/java/iudx/gis/server/authenticator/Constants.java
@@ -6,7 +6,7 @@ public class Constants {
   public static final List<String> OPEN_ENDPOINTS = List.of("/entities");
   public static final long CACHE_TIMEOUT_AMOUNT = 30;
   public static final String CAT_ITEM_PATH = "/item";
-  public static final String CAT_SEARCH_PATH = "/iudx/cat/v1/search";
+  public static final String CAT_SEARCH_PATH = "/search";
 
   public static final String AUTH_CERTIFICATE_PATH = "/cert";
   public static final String JSON_USERID = "userid";

--- a/src/main/java/iudx/gis/server/authenticator/Constants.java
+++ b/src/main/java/iudx/gis/server/authenticator/Constants.java
@@ -5,9 +5,10 @@ import java.util.List;
 public class Constants {
   public static final List<String> OPEN_ENDPOINTS = List.of("/entities");
   public static final long CACHE_TIMEOUT_AMOUNT = 30;
-  public static final String CAT_RSG_PATH = "/iudx/cat/v1/search";
-  public static final String CAT_ITEM_PATH = "/iudx/cat/v1/item";
+  public static final String CAT_ITEM_PATH = "/item";
+  public static final String CAT_SEARCH_PATH = "/iudx/cat/v1/search";
 
+  public static final String AUTH_CERTIFICATE_PATH = "/cert";
   public static final String JSON_USERID = "userid";
   public static final String JSON_IID = "iid";
   public static final String JSON_EXPIRY = "expiry";

--- a/src/main/java/iudx/gis/server/authenticator/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/gis/server/authenticator/JwtAuthenticationServiceImpl.java
@@ -1,10 +1,5 @@
 package iudx.gis.server.authenticator;
 
-import static iudx.gis.server.authenticator.Constants.JSON_EXPIRY;
-import static iudx.gis.server.authenticator.Constants.JSON_IID;
-import static iudx.gis.server.authenticator.Constants.JSON_USERID;
-import static iudx.gis.server.authenticator.Constants.OPEN_ENDPOINTS;
-
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.vertx.core.AsyncResult;
@@ -40,6 +35,8 @@ import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import static iudx.gis.server.authenticator.Constants.*;
+
 public class JwtAuthenticationServiceImpl implements AuthenticationService {
 
   private static final Logger LOGGER = LogManager.getLogger(JwtAuthenticationServiceImpl.class);
@@ -54,6 +51,7 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
   final CacheService cache;
   final String adminBasePath;
   final Api api;
+  final String catBasePath;
   // resourceIdCache will contain info about resources available(& their ACL) in resource server.
   public Cache<String, String> resourceIdCache =
       CacheBuilder.newBuilder()
@@ -78,7 +76,8 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     this.iss = config.getString("authServerHost");
     this.host = config.getString("catServerHost");
     this.port = config.getInteger("catServerPort");
-    this.path = Constants.CAT_RSG_PATH;
+    this.catBasePath = config.getString("dxCatalogueBasePath");
+    this.path = catBasePath + CAT_SEARCH_PATH;
     this.cache = cacheService;
     this.api = api;
     this.adminBasePath = config.getString("adminBasePath");

--- a/src/test/java/iudx/gis/server/authenticator/JwtAuthServiceImplTest.java
+++ b/src/test/java/iudx/gis/server/authenticator/JwtAuthServiceImplTest.java
@@ -56,11 +56,14 @@ public class JwtAuthServiceImplTest {
 
     authConfig.put("audience", "rs.iudx.io");
     authConfig.put("authServerHost", "authvertx.iudx.io");
+    authConfig.put("dxCatalogueBasePath", "/iudx/cat/v1");
+    authConfig.put("dxAuthBasePath", "/auth/v1");
     LOGGER.info("config : {}", authConfig);
 
     cacheServiceMock = Mockito.mock(CacheService.class);
     dxApiBasePath = authConfig.getString("dxApiBasePath");
     adminBasePath = authConfig.getString("adminBasePath");
+
     api = Api.getInstance(dxApiBasePath,adminBasePath);
 
     JWTAuthOptions jwtAuthOptions = new JWTAuthOptions();

--- a/src/test/resources/IUDX_GIS_Server_APIs_V4.0.environment.json
+++ b/src/test/resources/IUDX_GIS_Server_APIs_V4.0.environment.json
@@ -45,6 +45,11 @@
 			"enabled": true
 		},
 		{
+			"key": "dxAuthBasePath",
+			"value": "auth/v1",
+			"enabled": true
+		},
+		{
 			"key": "auth-url",
 			"value": "authvertx.iudx.io",
 			"type": "default",

--- a/src/test/resources/IUDX_GIS_Server_APIs_V4.0.postman_collection.json
+++ b/src/test/resources/IUDX_GIS_Server_APIs_V4.0.postman_collection.json
@@ -46,14 +46,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -113,14 +112,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}

--- a/src/test/resources/README.md
+++ b/src/test/resources/README.md
@@ -1,8 +1,8 @@
 ### Making configurable base path
 - Base path can be added in postman environment file or in postman.
-- `IUDX_GIS_Server_APIs_V4.0.environment.json` has **values** array which has a fields named **dxApiBasePath** whose **value** is currently set to `ngsi-ld/v1` and **adminBasePath** with **value** `admin/gis`.
+- `IUDX_GIS_Server_APIs_V4.0.environment.json` has **values** array which has fields named **dxApiBasePath** whose **value** is currently set to `ngsi-ld/v1`, **adminBasePath** with **value** `admin/gis`, **dxAuthBasePath** with value `auth/v1`.
 - These **values** could be changed according to the deployment and then the collection with the environment file can be uploaded to Postman
-- For the changing the **dxApiBasePath**, **adminBasePath** values in postman after importing the collection and environment files, locate `GIS Environment` from **Environments** in sidebar of Postman application.
+- For the changing the **dxApiBasePath**, **adminBasePath**,**adminBasePath** values in postman after importing the collection and environment files, locate `GIS Environment` from **Environments** in sidebar of Postman application.
 - To know more about Postman environments, refer : [postman environments](https://learning.postman.com/docs/sending-requests/managing-environments/)
 - The **CURRENT VALUE** of the variable could be changed
 


### PR DESCRIPTION
- Referencing datakaveri/iudx-resource-server#368
- Made Catalogue Server base path `iudx/cat/v1`, AAA Server base path `auth/v1` configurable by [updating the files](https://github.com/datakaveri/iudx-gis-interface/pull/85/commits/e795c31a471ebdc7c964b33821a91437361eaedb). 
- - Changes made in config-dev : 
```
	  "commonConfig" : {
            "dxApiBasePath": "/ngsi-ld/v1",
            "adminBasePath": "/admin/gis",
            "dxCatalogueBasePath": "/iudx/cat/v1",
            "dxAuthBasePath": "/auth/v1"
            },
```
- Changes made in Postman environment file : 
```
              {
		"key": "dxAuthBasePath",
		"value": "auth/v1",
		"enabled": true
	      },
```